### PR TITLE
[MERGE][FIX] fix Deserializer Page<T> from Redis Cache (Error: You have to provide at least one property to sort by)

### DIFF
--- a/IMPROOK_CARE/src/main/java/com/tuantran/IMPROOK_CARE/configs/redis/RestPage.java
+++ b/IMPROOK_CARE/src/main/java/com/tuantran/IMPROOK_CARE/configs/redis/RestPage.java
@@ -1,0 +1,26 @@
+package com.tuantran.IMPROOK_CARE.configs.redis;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = { "pageable" })
+public class RestPage<T> extends PageImpl<T> {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") List<T> content,
+            @JsonProperty("number") int page,
+            @JsonProperty("size") int size,
+            @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/IMPROOK_CARE/src/main/java/com/tuantran/IMPROOK_CARE/service/Impl/MedicineServiceImpl.java
+++ b/IMPROOK_CARE/src/main/java/com/tuantran/IMPROOK_CARE/service/Impl/MedicineServiceImpl.java
@@ -6,6 +6,7 @@ package com.tuantran.IMPROOK_CARE.service.Impl;
 
 import com.tuantran.IMPROOK_CARE.Specifications.GenericSpecifications;
 import com.tuantran.IMPROOK_CARE.components.cloudinary.CloudinaryComponent;
+import com.tuantran.IMPROOK_CARE.configs.redis.RestPage;
 import com.tuantran.IMPROOK_CARE.dto.AddMedicineDTO;
 import com.tuantran.IMPROOK_CARE.dto.UpdateMedicineDTO;
 import com.tuantran.IMPROOK_CARE.models.Medicine;
@@ -192,23 +193,9 @@ public class MedicineServiceImpl implements MedicineService {
         }
     }
 
-    // @Cacheable(value = "findAllMedicinePageSpec")
+    @Cacheable(value = "findAllMedicinePageSpec")
     @Override
     public Page<Medicine> findAllMedicinePageSpec(Map<String, String> params) {
-
-        // Page<Medicine> cache_1 = (Page<Medicine>)
-        // redisTemplate.opsForValue().get("alo_1");
-        // System.err.println(cache_1);
-        // Object cache = this.baseRedisService.get("alo");
-        // System.err.println(cache);
-
-        // String stringCache = (String) ;
-        // System.out.println(
-        // "++++++++++++++++++++++++++++++++++++++++++++++++++ LẤY TRONG CACHE RA
-        // ++++++++++++++++++++++++++++++++++++++++++");
-        // System.out.println(this.baseRedisService.get("alo_1"));
-        // System.out.println(
-        // "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
         String pageNumber = params.get("pageNumber");
         String medicineName = params.get("medicineName");
         String fromPrice = params.get("fromPrice");
@@ -255,24 +242,8 @@ public class MedicineServiceImpl implements MedicineService {
         Specification<Medicine> spec = GenericSpecifications.fieldEquals("active", Boolean.TRUE);
         listSpec.add(spec);
 
-        // this.baseRedisService.hashSet("ALO", "findAllMedicinePageSpec",
-        // this.medicineRepository.findAll(GenericSpecifications.createSpecification(listSpec),
-        // page));
-
-        // this.baseRedisService.setPage("alo",
-        // this.medicineRepository.findAll(GenericSpecifications.createSpecification(listSpec),
-        // page));
-
-        // System.out.println(
-        // "+++++++++++++++++++++++++++++++++++++++++ ADU
-        // +++++++++++++++++++++++++++++++++++++++++++++++++++");
-        // this.baseRedisService.setPage("alo_1",
-        // this.medicineRepository.findAll(GenericSpecifications.createSpecification(listSpec),
-        // page));
-        // System.out.println(
-        // "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-
-        return this.medicineRepository.findAll(GenericSpecifications.createSpecification(listSpec), page);
+        return new RestPage<>(
+                this.medicineRepository.findAll(GenericSpecifications.createSpecification(listSpec), page));
     }
 
     @Cacheable("findMedicineCache")


### PR DESCRIPTION
# About 

>- **Problem:** This error occurs when I store data of type Page into the Redis Cache, and then retrieve that data from Redis, it throws an error.
- Failed to complete request: org.springframework.data.redis.serializer.SerializationException: Could not read JSON:Cannot construct instance of `org.springframework.data.domain.Sort`, problem: You have to provide at least one property to sort by

```
2024-04-20T19:43:30.814+07:00 DEBUG 12072 --- [nio-2024-exec-3] o.s.web.servlet.DispatcherServlet        : Failed to complete request: org.springframework.data.redis.serializer.SerializationException: Could not read JSON:Cannot construct instance of `org.springframework.data.domain.Sort`, problem: You have to provide at least one property to sort by
 at [Source: (byte[])"["org.springframework.data.domain.PageImpl",{"content":["java.util.Collections$UnmodifiableRandomAccessList",[["com.tuantran.IMPROOK_CARE.models.Medicine",{"medicineId":44,"medicineName":"Thuß╗æc th├¬m api","description":"Thuß╗æc th├¬m api","ingredients":"Thuß╗æc th├¬m api","dosage":"Thuß╗æc th├¬m api","avatar":"https://res.cloudinary.com/dhwuwy0to/image/upload/v1702125741/ttnhcxqslu0vzmt8pgui.jpg","unitPrice":["java.math.BigDecimal",10000.00],"createdDate":["java.sql.Timestamp","2023-12-09T12:4"[truncated 4637 bytes]; line: 1, column: 4882] (through reference chain: org.springframework.data.domain.PageImpl["pageable"]->org.springframework.data.domain.PageRequest["sort"])
```

> - **Solution:** Extend PageImpl and specify the required JsonProperties while explicitly ignoring the other ones: <br/>
![image](https://github.com/TuanTran0168/SpringBoot-ImprookCare/assets/82080825/343b8ccb-19b6-45a2-b5b4-eb438d78d06d)

> - **At my Service Implement** <br/>
![image](https://github.com/TuanTran0168/SpringBoot-ImprookCare/assets/82080825/017d04ec-ec78-4e21-a163-2f59c40517d3)

