### PR TITLE
[ADD][config/H2-in-memory] config H2 database for deploy Render

### DIFF
--- a/IMPROOK_CARE/pom.xml
+++ b/IMPROOK_CARE/pom.xml
@@ -49,7 +49,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <!-- use this if your lombok has erorr -->
-            <!-- <version>1.18.32</version> -->
+             <version>1.18.32</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -201,6 +201,12 @@
             <artifactId>itext7-core</artifactId>
             <version>7.2.4</version>
             <type>pom</type>
+        </dependency>
+        <!--	H2 for Testing Environment	-->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/IMPROOK_CARE/src/main/resources/application.properties
+++ b/IMPROOK_CARE/src/main/resources/application.properties
@@ -2,13 +2,22 @@
 server.servlet.context-path=/IMPROOK_CARE
 server.port=2024
 
-# Connect Database MySQL
-spring.datasource.url=jdbc:mysql://localhost:3307/improokcare
-spring.datasource.username=root
-spring.datasource.password=Admin@123
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:h2:mem:improokcare;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.entity-scan=com.tuantran.IMPROOK_CARE.models
+
+
+## Connect Database MySQL
+#spring.datasource.url=jdbc:mysql://localhost:3307/improokcare
+#spring.datasource.username=root
+#spring.datasource.password=Admin@123
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.jpa.show-sql=true
+#spring.jpa.entity-scan=com.tuantran.IMPROOK_CARE.models
 
 
 #Cloudinary


### PR DESCRIPTION
# Using H2 Database for Deployment

**In this project, we configure H2 Database as a lightweight, embedded database for deployment on platforms like Render.**

**Why H2?**

- H2 is a zero-configuration, embedded, in-memory or file-based database.
- It is suitable for testing, demos, or lightweight deployments where a persistent external database (like PostgreSQL or MySQL) is not available.
- H2 can also run in PostgreSQL compatibility mode, which makes migration to a real PostgreSQL database easier later.